### PR TITLE
Update .gitattributes

### DIFF
--- a/lab3/.gitattributes
+++ b/lab3/.gitattributes
@@ -1,1 +1,2 @@
 docs/* linguist-vendored
+*.sh text eol=lf


### PR DESCRIPTION
The difference in line endings between Windows and Linux environments causes .sh files to fail when running in a Docker container on Windows.