### PR TITLE
fix: change 4 spaces into a tab in dc91bac

### DIFF
--- a/lab1/Makefile
+++ b/lab1/Makefile
@@ -6,7 +6,7 @@ TARGETS := test0 test1 test2 test3 test4 test5 test6 test7 test8 test9
 all: $(TARGETS)
 
 results/afl_logs/%/out.txt: c_programs/%.c
-    @mkdir -p afl_output/
+	@mkdir -p afl_output/
 	@mkdir -p results/afl_logs/$*
 	AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1 AFL_DONT_OPTIMIZE=1 afl-gcc $< -o $* 2>/dev/null
 	-AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1 timeout 30s afl-fuzz -m none -i afl_input -o afl_output -- ./$* > $@ 2>/dev/null


### PR DESCRIPTION
There should not be 4 spaces, which will lead to
```
$ make all
Makefile:9: *** missing separator.  Stop.
```
There is expected to be a tab.