### PR TITLE
[fixup] remove results/ from lab1/.gitignore

### DIFF
--- a/lab1/.gitignore
+++ b/lab1/.gitignore
@@ -1,6 +1,5 @@
 afl_output/
 .DS_Store
-results/
 output.db
 submission/
 submission.zip


### PR DESCRIPTION
`lab1/results/` shouldn't be ignored by git.